### PR TITLE
feat(#44): 예약 확정 후 취소

### DIFF
--- a/src/main/java/kr/co/petmates/api/bussiness/reserve/dto/RequestCancelBookingDto.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/reserve/dto/RequestCancelBookingDto.java
@@ -1,0 +1,20 @@
+package kr.co.petmates.api.bussiness.reserve.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestCancelBookingDto {
+    private Long id; // 예약 ID
+
+    private String code; // 취소 사유 코드
+
+    // "canceledTime": "2024-03-06T06:54:25" 대신 "canceledTime": "2024-03-06 06:54:25"처럼 처리
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+//    @DateTimeFormat(pattern = "yyyy-MM-dd hh:mm:ss")
+    private LocalDateTime canceledTime; // 취소 시간
+}
+

--- a/src/main/java/kr/co/petmates/api/bussiness/reserve/dto/ResponseCancelBookingDto.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/reserve/dto/ResponseCancelBookingDto.java
@@ -1,0 +1,32 @@
+package kr.co.petmates.api.bussiness.reserve.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResponseCancelBookingDto {
+    private final String result;
+
+    private final Object data;
+
+    // 성공 데이터 객체
+    @Builder
+    @Getter
+    public static class SuccessData {
+        private final Long id;
+        private final Long bookId;
+        private final String code;
+        private final LocalDateTime canceledTime;
+        private final String status;
+    }
+
+    // 실패 데이터 객체
+    @Builder
+    @Getter
+    public static class FailedData {
+        private final String reason;
+    }
+}
+

--- a/src/main/java/kr/co/petmates/api/bussiness/reserve/repository/CanceledBookingRepository.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/reserve/repository/CanceledBookingRepository.java
@@ -1,0 +1,7 @@
+package kr.co.petmates.api.bussiness.reserve.repository;
+
+import kr.co.petmates.api.bussiness.reserve.entity.CanceledBooking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CanceledBookingRepository extends JpaRepository<CanceledBooking, Long> {
+}

--- a/src/main/java/kr/co/petmates/api/bussiness/reserve/service/BookingService.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/reserve/service/BookingService.java
@@ -1,8 +1,13 @@
 package kr.co.petmates.api.bussiness.reserve.service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import kr.co.petmates.api.bussiness.reserve.dto.BookingDto;
+import kr.co.petmates.api.bussiness.reserve.entity.Booking;
+import kr.co.petmates.api.bussiness.reserve.entity.CanceledBooking;
 import kr.co.petmates.api.bussiness.reserve.repository.BookingRepository;
+import kr.co.petmates.api.bussiness.reserve.repository.CanceledBookingRepository;
+import kr.co.petmates.api.enums.BookingStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BookingService {
     private final BookingRepository bookingRepository;
+    private final CanceledBookingRepository canceledBookingRepository;
 
     // 예약 내역 리스트 조회
     public Page<BookingDto> findBookingsByMemberId(Long memberId, Pageable pageable) {
@@ -29,5 +35,28 @@ public class BookingService {
     @Transactional(readOnly = true)
     public Optional<BookingDto> findBookingById(Long bookingId) {
         return bookingRepository.findById(bookingId).map(BookingDto::toBookingDto);
+    }
+
+    @Transactional
+    public CanceledBooking cancelBooking(Long bookingId, LocalDateTime canceledTime) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new RuntimeException("Booking not found"));
+
+        if (booking.getCanceledBooking() != null) {
+            throw new RuntimeException("Booking already canceled");
+        }
+
+        booking.setStatus(BookingStatus.BOOK_CANCELED);
+
+        CanceledBooking canceledBooking = new CanceledBooking();
+        canceledBooking.setBooking(booking);
+        canceledBooking.setFee(booking.getFee());
+        canceledBooking.setAmount(booking.getTotalPrice().subtract(booking.getFee()));
+        canceledBooking.setCanceledTime(canceledTime);
+        booking.setCanceledBooking(canceledBooking);
+
+        bookingRepository.save(booking);
+
+        return canceledBooking;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
       - dev
 #      - prod
 
+#  "canceledTime": "2024-03-06T06:54:25" 대신 "canceledTime": "2024-03-06 06:54:25"처럼 처리
+  jackson:
+    date-format: yyyy-MM-dd HH:mm:ss
   docker:
     compose:
       skip:


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* feat(#44): 반려인과 펫시터간의 예약이 된 후에 반려인 측에서 예약을 취소를 할 수 있도록 하였습니다.

# 어떻게 해결했나요?
* 예약 취소 요청이 들어오면, BOOKING테이블.STATUS 필드값을 "BOOK_CANCELED"으로 업데이트하고, canceled_booking테이블에 취소 내역을 추가합니다.
* 취소 요청에 대한 성공과 실패에 대한 응답을 반환합니다.

# 남은 해결 과제는 무엇인가요?
* 고도화할 경우에 카카오 페이 도입 시, 페이 상에서 결제 취소가 이루어지는 내역이 반영이 되어야하며, 관련 상태 코드도 진행 상태에 맞게 변경이 되어야 합니다.
* JWT 토큰으로 반려인의 본인 요청에 대해 처리하도록 해야 합니다.