### PR TITLE
fix(#50) Pet엔티티의 성별 타입 변경

### DIFF
--- a/src/main/java/kr/co/petmates/api/bussiness/pet/dto/PetDto.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/dto/PetDto.java
@@ -1,6 +1,5 @@
 package kr.co.petmates.api.bussiness.pet.dto;
 
-import com.nimbusds.openid.connect.sdk.claims.Gender;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import kr.co.petmates.api.bussiness.pet.entity.Pet;
@@ -36,17 +35,19 @@ public class PetDto {
     @Pattern(regexp = "^[0-9]{1,2}$|^(100)$\n")
     private String weight; // 몸무게
 
-    private Gender sex; // 성별
+    private String sex; // 성별
 
-    private boolean isNeutering; // 중성화
+    private Boolean isNeutering; // 중성화
 
-    private boolean isAllergy; // 알러지
+    private Boolean isAllergy; // 알러지
 
-    private boolean isDisease; // 질병
+    private Boolean isDisease; // 질병
 
     private String etc; // 참고사항
 
     private String photoUrl; // 사진 접근을 위한 URL
+
+    private Boolean isDeleted;
 
 
     public static PetDto toPetDto(Pet pet) { // entity -> dto
@@ -57,6 +58,11 @@ public class PetDto {
         petDto.setWeight(pet.getWeight());
         petDto.setSex(pet.getSex());
         petDto.setEtc(pet.getEtc());
+
+        petDto.setIsNeutering(pet.getIsNeutering());
+        petDto.setIsAllergy(pet.getIsAllergy());
+        petDto.setIsDisease(pet.getIsDisease());
+        petDto.setIsDeleted(pet.getIsDeleted());
 
         return petDto;
     }

--- a/src/main/java/kr/co/petmates/api/bussiness/pet/entity/Pet.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/entity/Pet.java
@@ -1,6 +1,5 @@
 package kr.co.petmates.api.bussiness.pet.entity;
 
-import com.nimbusds.openid.connect.sdk.claims.Gender;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,7 +56,7 @@ public class Pet extends BaseDateTimeEntity implements Serializable {
     private String weight; // 몸무게
 
     @Column(nullable = false)
-    private Gender sex; // 성별
+    private String sex; // 성별
 
     @Column(nullable = false)
     private Boolean isNeutering; // 중성화
@@ -71,6 +70,9 @@ public class Pet extends BaseDateTimeEntity implements Serializable {
     @Column(columnDefinition = "LONGTEXT")
     private String etc; // 참고사항
 
+    @Column
+    private Boolean isDeleted = false;
+
     public static Pet toPetEntity(PetDto petDto) { // dto -> entity
         Pet pet = new Pet();
         pet.setName(petDto.getName());
@@ -79,6 +81,12 @@ public class Pet extends BaseDateTimeEntity implements Serializable {
         pet.setWeight(petDto.getWeight());
         pet.setSex(petDto.getSex());
         pet.setEtc(petDto.getEtc());
+
+        pet.setIsNeutering(petDto.getIsNeutering());
+        pet.setIsAllergy(petDto.getIsAllergy());
+        pet.setIsDisease(petDto.getIsDisease());
+        pet.setIsDeleted(petDto.getIsDeleted() != null && petDto.getIsDeleted());
+
         return pet;
     }
 

--- a/src/main/java/kr/co/petmates/api/config/security/SecurityConfig.java
+++ b/src/main/java/kr/co/petmates/api/config/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
 //                                .requestMatchers(PathRequest.toH2Console()).permitAll()// favicon.ico 요청 인증 무시
                                 .requestMatchers("/api/kakao/**", "/api/oauth/**", "/api/members/**", "/api/petsitter/**", "/api/my-page/**", "/api/reserve/**").permitAll()
                                 .requestMatchers("/adm/test", "/api/ide/**", "/api/chat/**", "/chat/**").authenticated() // 로그인했을 때 접근 허용
+                                .requestMatchers("/v3/**", "/swagger-ui/**", "/api/reserve/**").permitAll() // 접근 허용
 //                                .requestMatchers("/api/kakao/**", "/api/oauth/**", "/api/members/join", "/api/members/join/save", "/api/members/join/doublecheck", "/api/members/delete", "/api/members/test","/api/my-page/**",
 //                                        "/v3/**", "/swagger-ui/**", "/api/reserve/**",
 //                                        "/api/members/login").permitAll() // 접근 허용


### PR DESCRIPTION
- 코드를 인수받은 상태에서, 기존 코드에서는 API 명세서와 다르게, 중성화, 알러지, 질병 유무가 등록되지 않았습니다. 이를 수정하였습니다.

- API로 성별 조회 후 응답 과정에서 역직렬화가 되지 않습니다. 따라서 Gender 대신 String을 사용하도록 수정하였습니다.

- 반려동물을 삭제했을 때, 펫시터 측에서도 참고를 하기 때문에 레코드 삭제 대신에 레코드 삭제 유무를 알 수 있는 isDeleted 필드를 추가하였습니다.