### PR TITLE
feat(#47): 반려인의 반려동물 정보 목록

### DIFF
--- a/src/main/java/kr/co/petmates/api/bussiness/pet/controller/PetController.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/controller/PetController.java
@@ -2,7 +2,10 @@ package kr.co.petmates.api.bussiness.pet.controller;
 
 
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
 import kr.co.petmates.api.bussiness.pet.dto.PetDto;
+import kr.co.petmates.api.bussiness.pet.dto.PetResponseDto;
 import kr.co.petmates.api.bussiness.pet.service.PetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -63,4 +66,18 @@ public class PetController {
 //            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorRes);
 //        }
 //    }
+
+    @GetMapping("my-page/pet/{membersId}")
+    public ResponseEntity<?> myPetList(@PathVariable("membersId") Long membersId) {
+        try {
+            List<PetResponseDto> pets = petService.findPetsByOwnerId(membersId);
+            return ResponseEntity.ok(Map.of("result", "success", "data", pets));
+        } catch (RuntimeException e) {
+            return ResponseEntity.ok(Map.of("result", "failed",
+                    "data", Map.of("reason", e.getMessage())));
+            // 400 에러
+//            return ResponseEntity.badRequest().body(Map.of("result", "failed",
+//                    "data", Map.of("reason", e.getMessage())));
+        }
+    }
 }

--- a/src/main/java/kr/co/petmates/api/bussiness/pet/dto/PetResponseDto.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/dto/PetResponseDto.java
@@ -1,0 +1,72 @@
+package kr.co.petmates.api.bussiness.pet.dto;
+
+import kr.co.petmates.api.bussiness.pet.entity.Pet;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+//@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PetResponseDto {
+
+    private Long id; // 시퀀스
+
+    private Long membersId; // 멤버를 참조하기 위한 ID
+
+    private Long petPhotoId;
+
+    private String name; // 이름
+
+    private String breed; // 견종
+
+    private String birthYear; // 출생년도
+
+    private String weight; // 몸무게
+
+//    private Gender sex; // 성별
+
+    private boolean isNeutering; // 중성화
+
+    private boolean isAllergy; // 알러지
+
+    private boolean isDisease; // 질병
+
+    private String etc; // 참고사항
+
+    private String photoUrl; // 사진 접근을 위한 URL
+
+    @Builder
+    public PetResponseDto(Long id, Long membersId, Long petPhotoId, String name, String breed, String birthYear,
+                          String weight, /* Gender sex, */ boolean isNeutering, boolean isAllergy, boolean isDisease,
+                          String etc, String photoUrl) {
+        this.id = id;
+        this.membersId = membersId;
+        this.petPhotoId = petPhotoId;
+        this.name = name;
+        this.breed = breed;
+        this.birthYear = birthYear;
+        this.weight = weight;
+//        this.sex = sex;
+        this.isNeutering = isNeutering;
+        this.isAllergy = isAllergy;
+        this.isDisease = isDisease;
+        this.etc = etc;
+        this.photoUrl = photoUrl;
+    }
+
+
+    public static PetResponseDto toPetDto(Pet pet) { // entity -> dto
+        PetResponseDto petDto = new PetResponseDto();
+        petDto.setName(pet.getName());
+        petDto.setBreed(pet.getBreed());
+        petDto.setBirthYear(pet.getBirthYear());
+        petDto.setWeight(pet.getWeight());
+//        petDto.setSex(pet.getSex());
+        petDto.setEtc(pet.getEtc());
+
+        return petDto;
+    }
+}
+

--- a/src/main/java/kr/co/petmates/api/bussiness/pet/entity/Pet.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/entity/Pet.java
@@ -70,7 +70,8 @@ public class Pet extends BaseDateTimeEntity implements Serializable {
     @Column(columnDefinition = "LONGTEXT")
     private String etc; // 참고사항
 
-    @Column
+    // 삭제여부
+    @Column(nullable = false)
     private Boolean isDeleted = false;
 
     public static Pet toPetEntity(PetDto petDto) { // dto -> entity

--- a/src/main/java/kr/co/petmates/api/bussiness/pet/repository/PetRepository.java
+++ b/src/main/java/kr/co/petmates/api/bussiness/pet/repository/PetRepository.java
@@ -1,9 +1,22 @@
 package kr.co.petmates.api.bussiness.pet.repository;
 
 import java.util.List;
+import kr.co.petmates.api.bussiness.pet.dto.PetResponseDto;
 import kr.co.petmates.api.bussiness.pet.entity.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
     List<Pet> findByOwner_Id(Long ownerId);
+
+//    @Query("SELECT p FROM Pet p JOIN FETCH p.owner o LEFT JOIN FETCH p.petPhoto pp WHERE o.id = :ownerId")
+    @Query("SELECT new kr.co.petmates.api.bussiness.pet.dto.PetResponseDto(p.id, p.owner.id, p.petPhoto.id, "
+            + "p.name, p.breed, p.birthYear, p.weight, p.isNeutering, p.isAllergy, p.isDisease, p.etc, "
+            + "p.petPhoto.storedFileName) "
+            + "FROM Pet p LEFT JOIN PetPhoto pp ON p.id = pp.pet.id "
+            + "WHERE p.owner.id = :ownerId and p.isDeleted = false")
+    List<PetResponseDto> findByMembersId(@Param("ownerId") Long ownerId);
+
+
 }


### PR DESCRIPTION
- Members 테이블에 연관되어 있는 테이블 중에 불필요한 테이블과 Join 연산이 되지 않도록, 그리고 N + 1 문제가 생기지 않도록, 별도의 PetResponseDto를 제작한 뒤, 이를 이용해서 쿼리를 하도록 하였습니다.

- PetRepository.findByMembersId를 보시면, Pet 테이블을 가져올 때 조건은, Pet.MembersId를 통해, 반려인을 쿼리합니다. 이 때, Pet.isDeleted = false인 삭제되지 않은 레코드를 가져옵니다. 또 한편으로 Pet을 조회해서 가져올 때, PetPhoto를 Join해서 연관된 사진도 가져옵니다.
참고로, 기존에 작업하신 분이 Pet과 PetPhoto 간에 1:1로 연관을 맺도록 하였고, 팀에 확인 결과, 반려동물의 사진을 등록하지 않는다면, 기본 이미지를 등록하여 사용한다고 합니다.